### PR TITLE
feat: add endpoints for employee and client creation

### DIFF
--- a/src/main/java/com/pragma/userservice/application/handler/IUserHandler.java
+++ b/src/main/java/com/pragma/userservice/application/handler/IUserHandler.java
@@ -5,4 +5,8 @@ import jakarta.validation.Valid;
 
 public interface IUserHandler {
     void createOwner(@Valid UserDTO userDTO);
+
+    void createEmployee(@Valid UserDTO userDTO);
+
+    void createClient(@Valid UserDTO userDTO);
 }

--- a/src/main/java/com/pragma/userservice/application/handler/UserHandler.java
+++ b/src/main/java/com/pragma/userservice/application/handler/UserHandler.java
@@ -19,4 +19,16 @@ public class UserHandler implements IUserHandler {
         User userEntity = userDTOMapper.toEntity(userDTO);
         userServicePort.createOwner(userEntity);
     }
+
+    @Override
+    public void createEmployee(UserDTO userDTO) {
+        User userEntity = userDTOMapper.toEntity(userDTO);
+        userServicePort.createEmployee(userEntity);
+    }
+
+    @Override
+    public void createClient(UserDTO userDTO) {
+        User userEntity = userDTOMapper.toEntity(userDTO);
+        userServicePort.createClient(userEntity);
+    }
 }

--- a/src/main/java/com/pragma/userservice/domain/api/IUserServicePort.java
+++ b/src/main/java/com/pragma/userservice/domain/api/IUserServicePort.java
@@ -4,4 +4,8 @@ import com.pragma.userservice.domain.model.User;
 
 public interface IUserServicePort {
     void createOwner(User userEntity);
+
+    void createEmployee(User userEntity);
+
+    void createClient(User userEntity);
 }

--- a/src/main/java/com/pragma/userservice/domain/spi/IUserPersistencePort.java
+++ b/src/main/java/com/pragma/userservice/domain/spi/IUserPersistencePort.java
@@ -9,5 +9,5 @@ public interface IUserPersistencePort {
 
     Optional<User> findByPhoneNumber(String phoneNumber);
 
-    void saveUser(User userEntity, String owner);
+    void saveUser(User userEntity, String role);
 }

--- a/src/main/java/com/pragma/userservice/domain/usecase/UserService.java
+++ b/src/main/java/com/pragma/userservice/domain/usecase/UserService.java
@@ -24,13 +24,32 @@ public class UserService implements IUserServicePort {
     @Override
     public void createOwner(User userEntity) {
         userEntity.setPassword(passwordServicePort.encodePassword(userEntity.getPassword()));
+        validateUser(userEntity, true);
+        userPersistencePort.saveUser(userEntity, "OWNER");
+    }
+
+    @Override
+    public void createEmployee(User userEntity) {
+        userEntity.setPassword(passwordServicePort.encodePassword(userEntity.getPassword()));
+        validateUser(userEntity, false);
+        userPersistencePort.saveUser(userEntity, "EMPLOYEE");
+    }
+
+    @Override
+    public void createClient(User userEntity) {
+        userEntity.setPassword(passwordServicePort.encodePassword(userEntity.getPassword()));
+        validateUser(userEntity, false);
+        userPersistencePort.saveUser(userEntity, "CLIENT");
+    }
+
+    private void validateUser(User userEntity, boolean validateAge) {
         if (!validateCellphone(userEntity.getPhoneNumber())) {
             throw new IllegalArgumentException("Invalid cellphone number");
         }
         if (!validateDocument(userEntity.getIdentificationNumber())) {
             throw new IllegalArgumentException("Invalid document number");
         }
-        if (Period.between(userEntity.getBirthDate(), LocalDate.now()).getYears() < 18) {
+        if (validateAge && Period.between(userEntity.getBirthDate(), LocalDate.now()).getYears() < 18) {
             throw new IllegalArgumentException("User must be at least 18 years old");
         }
         if (userPersistencePort.findByEmail(userEntity.getEmail()).isPresent()) {
@@ -39,8 +58,5 @@ public class UserService implements IUserServicePort {
         if (userPersistencePort.findByPhoneNumber(userEntity.getPhoneNumber()).isPresent()) {
             throw new IllegalArgumentException("Phone number already exists");
         }
-        userPersistencePort.saveUser(userEntity, "OWNER");
-
-
     }
 }

--- a/src/main/java/com/pragma/userservice/infraestructure/input/rest/UserController.java
+++ b/src/main/java/com/pragma/userservice/infraestructure/input/rest/UserController.java
@@ -28,4 +28,16 @@ public class UserController {
         userHandler.createOwner(userDTO);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
+
+    @PostMapping("/employee")
+    public ResponseEntity<Void> createEmployee(@Valid @RequestBody UserDTO userDTO) {
+        userHandler.createEmployee(userDTO);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @PostMapping("/client")
+    public ResponseEntity<Void> createClient(@Valid @RequestBody UserDTO userDTO) {
+        userHandler.createClient(userDTO);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
 }

--- a/src/main/java/com/pragma/userservice/infraestructure/output/jpa/adapter/UserJpaAdapter.java
+++ b/src/main/java/com/pragma/userservice/infraestructure/output/jpa/adapter/UserJpaAdapter.java
@@ -28,10 +28,9 @@ public class UserJpaAdapter implements IUserPersistencePort {
     }
 
     @Override
-    public void saveUser(User user, String owner) {
+    public void saveUser(User user, String role) {
         UserEntity entity = userEntityMapper.toEntity(user);
-        // TODO: set owner role if needed
-
+        entity.setRole(role);
         userRepository.save(entity);
     }
 }

--- a/src/main/java/com/pragma/userservice/infraestructure/output/jpa/entity/UserEntity.java
+++ b/src/main/java/com/pragma/userservice/infraestructure/output/jpa/entity/UserEntity.java
@@ -30,5 +30,6 @@ public class UserEntity {
     private LocalDate birthDate;
     private String email;
     private String password;
+    private String role;
 
 }


### PR DESCRIPTION
## Summary
- allow service and handler to create EMPLOYEE and CLIENT users
- expose new `/users/employee` and `/users/client` endpoints
- persist user role when saving

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.5.3'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f497c934832e9d0933924be3d41e